### PR TITLE
avoid async shells

### DIFF
--- a/better-shell.el
+++ b/better-shell.el
@@ -94,6 +94,7 @@ prompt."
   (cl-remove-if-not
    (lambda (buf)
      (and
+      (not (s-starts-with? "*Async Shell" (buffer-name buf)))
       (get-buffer-process buf)
       (with-current-buffer buf
         (string-equal major-mode 'shell-mode))))


### PR DESCRIPTION
Many of my commands spawn async shell processes, which are then a useless part of the list that is cycled through. This causes `async-shell-command` buffers to be ignored by better-shell. 